### PR TITLE
Fix 'always' preferred app assignment

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -3524,7 +3524,7 @@ public class PackageManagerService extends IPackageManager.Stub {
                             // If the result set is different from when this
                             // was created, we need to clear it and re-ask the
                             // user their preference, if we're looking for an "always" type entry.
-                            if (always && !pa.mPref.sameSet(query, priority)) {
+                            if (always && !pa.mPref.sameSet(query)) {
                                 Slog.i(TAG, "Result set changed, dropping preferred activity for "
                                         + intent + " type " + resolvedType);
                                 if (DEBUG_PREFERRED) {

--- a/services/core/java/com/android/server/pm/PreferredComponent.java
+++ b/services/core/java/com/android/server/pm/PreferredComponent.java
@@ -192,7 +192,7 @@ public class PreferredComponent {
         }
     }
 
-    public boolean sameSet(List<ResolveInfo> query, int priority) {
+    public boolean sameSet(List<ResolveInfo> query) {
         if (mSetPackages == null) {
             return query == null;
         }
@@ -201,10 +201,10 @@ public class PreferredComponent {
         }
         final int NQ = query.size();
         final int NS = mSetPackages.length;
+
         int numMatch = 0;
         for (int i=0; i<NQ; i++) {
             ResolveInfo ri = query.get(i);
-            if (ri.priority != priority) continue;
             ActivityInfo ai = ri.activityInfo;
             boolean good = false;
             for (int j=0; j<NS; j++) {


### PR DESCRIPTION
In the case when some possible resolutions of a given intent are at
different priorities (typically when they're intended as fallbacks when
no "normal" handler for the intent exists) the check for "is this the
same set of possible handlers that we saw last time?" was broken.  We
now ignore resolver priority entirely in that check: match set comparison
should be orthogonal to prioritization within the set, and indeed the
priority is dealt with separately in any event.

Bug 19011225

Change-Id: I3c1658442cc88b1f4a5c5f2fe9f64472799e156c