### PR TITLE
base: fix window bounds for left hand navigationbar

### DIFF
--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -4367,7 +4367,6 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     int right = overscanLeft + mNavigationBarWidthForRotation[displayRotation];
                     mTmpNavigationFrame.set(0, 0, right, displayHeight);
                     mStableLeft = mStableFullscreenLeft = mTmpNavigationFrame.right;
-                    mStableFullscreenLeft = mTmpNavigationFrame.right;
                     if (transientNavBarShowing) {
                         mNavigationBarController.setBarShowingLw(true);
                     } else if (navVisible) {
@@ -4618,7 +4617,12 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         }
     }
 
-    private void applyStableConstraints(int sysui, int fl, Rect r) {
+    private void applyStableConstraints(int sysui, int fl, Rect r, Rect d) {
+        if (mNavigationBarLeftInLandscape) {
+            d.left = r.left;
+            r.left = 0;
+        }
+
         if ((sysui & View.SYSTEM_UI_FLAG_LAYOUT_STABLE) != 0) {
             // If app is requesting a stable layout, don't let the
             // content insets go below the stable values.
@@ -4863,7 +4867,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                         cf.right = mRestrictedScreenLeft + mRestrictedScreenWidth;
                         cf.bottom = mRestrictedScreenTop + mRestrictedScreenHeight;
                     }
-                    applyStableConstraints(sysUiFl, fl, cf);
+                    applyStableConstraints(sysUiFl, fl, cf, df);
                     if (adjust != SOFT_INPUT_ADJUST_NOTHING) {
                         vf.left = mCurLeft;
                         vf.top = mCurTop;
@@ -4978,7 +4982,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                             + mRestrictedScreenHeight;
                 }
 
-                applyStableConstraints(sysUiFl, fl, cf);
+                applyStableConstraints(sysUiFl, fl, cf, df);
 
                 if (adjust != SOFT_INPUT_ADJUST_NOTHING) {
                     vf.left = mCurLeft;


### PR DESCRIPTION
Currently in left-hand navigationbar mode all drawerlayouts have an inconsistent presentation
because the actual window size calculation code only takes into consideration the content
view. This problem is not present in the rest of the navigation modes because of the nature
of the position of the navigation bar. This patch fix the display and content layouts calculation.
To repro just set navigation mode to hand-left and access an app with a drawerlayout (xe:
the email app) in landscape mode.

Change-Id: I1394f39f4f5e7e6ac50b9558657685e86547acf3
Signed-off-by: Jorge Ruesga <jorge@ruesga.com>